### PR TITLE
Update weather.py - deprecated constants

### DIFF
--- a/custom_components/metnowcast/weather.py
+++ b/custom_components/metnowcast/weather.py
@@ -9,9 +9,9 @@ from homeassistant.const import (
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_NAME,
-    TEMP_CELSIUS,
-    SPEED_METERS_PER_SECOND,
-    LENGTH_MILLIMETERS,
+    UnitOfTemperature.CELSIUS,
+    UnitOfSpeed.METERS_PER_SECOND,
+    UnitOfLength.MILLIMETERS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -63,9 +63,9 @@ def format_condition(condition: str) -> str:
 class NowcastWeather(WeatherEntity):
     """Representation of a Nowcast sensor."""
 
-    _attr_native_temperature_unit = TEMP_CELSIUS
-    _attr_native_wind_speed_unit = SPEED_METERS_PER_SECOND
-    _attr_native_precipitation_unit = LENGTH_MILLIMETERS
+    _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_native_wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
+    _attr_native_precipitation_unit = UnitOfLength.MILLIMETERS
     _attr_supported_features = WeatherEntityFeature.FORECAST_HOURLY
 
     def __init__(


### PR DESCRIPTION
TEMP_CELSIUS was used from metnowcast, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'metnowcast' custom integration SPEED_METERS_PER_SECOND was used from metnowcast, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfSpeed.METERS_PER_SECOND instead, please report it to the author of the 'metnowcast' custom integration LENGTH_MILLIMETERS was used from metnowcast, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfLength.MILLIMETERS instead, please report it to the author of the 'metnowcast' custom integration